### PR TITLE
Port specification support for Api class.

### DIFF
--- a/suitable/module_runner.py
+++ b/suitable/module_runner.py
@@ -80,8 +80,10 @@ class ModuleRunner(object):
         loader = DataLoader()
         inventory_manager = SourcelessInventoryManager(loader=loader)
 
-        for host in self.api.servers:
-            inventory_manager._inventory.add_host(host, group='all')
+        for server, port in self.api.servers:
+            inventory_manager._inventory.add_host(
+                server, group='all', port=port
+            )
 
         for key, value in self.api.options.extra_vars.items():
             inventory_manager._inventory.set_variable('all', key, value)
@@ -91,7 +93,7 @@ class ModuleRunner(object):
 
         play_source = {
             'name': "Suitable Play",
-            'hosts': self.api.servers,
+            'hosts': self.api.servers.hosts,
             'gather_facts': 'no',
             'tasks': [{
                 'action': {


### PR DESCRIPTION
Hi,

I added ansible port specification support for Api class :grin: .

Before:

```python
api = Api(['192.168.1.1', '192.168.1.2'])
api = Api('192.168.1.1 192.168.1.2')
```

After:

```python
api = Api(['192.168.1.1:2222', '192.168.1.2:2223'])
api = Api('192.168.1.1:2222 192.168.1.2:2223')
```

And it's compatible with the original version. The original way to initialize the Api class is not broken.
In the original version, the port argument for InventoryData.add_host is always None, I just filled it.