### PR TITLE
Support modules with file extension other than .py

### DIFF
--- a/suitable/api.py
+++ b/suitable/api.py
@@ -346,7 +346,4 @@ def get_modules_from_path(path):
             for module in get_modules_from_path(path):
                 yield module
         else:
-            if name.endswith('.py'):
-                yield name[:-3]
-            else:
-                yield name
+            yield os.path.splitext(name)[0]


### PR DESCRIPTION
In case you have modules not written in python the file extension (e.g. `.sh`) should be removed as well. This allows us to use the module in suitable.