### PR TITLE
Add unreachable hosts to runner results

### DIFF
--- a/suitable/module_runner.py
+++ b/suitable/module_runner.py
@@ -331,5 +331,9 @@ class ModuleRunner(object):
             'contacted': {
                 server: answer['result']
                 for server, answer in callback.contacted.items()
+            },
+            'unreachable': {
+                server: result
+                for server, result in callback.unreachable.items()
             }
         })

--- a/suitable/tests/test_api.py
+++ b/suitable/tests/test_api.py
@@ -129,12 +129,12 @@ def test_unreachable(server):
     assert server not in host.servers
 
 
-@pytest.mark.parametrize("server", ('localhost', 'localhost:22'))
+@pytest.mark.parametrize("server", ('255.255.255.255', '255.255.255.255:22'))
 def test_ignore_unreachable(server):
     host = Api(server, ignore_unreachable=True)
-
     assert server in host.servers
-    host.command('whoami')
+    result = host.command('whoami')
+    assert server in result['unreachable']
     assert server in host.servers
 
 


### PR DESCRIPTION
In an automated environment it would be beneficial to get the unreachable hosts in case the flag `ignore_unreachable` is set to `True`. Due to that I propose to add the list of hosts to the `RunnersResult`.