### PR TITLE
Add success flag to results

### DIFF
--- a/suitable/module_runner.py
+++ b/suitable/module_runner.py
@@ -313,6 +313,9 @@ class ModuleRunner(object):
                 if self.api.is_valid_return_code(result['rc']):
                     success = True
 
+            # Add success to result
+            result['success'] = success
+
             if not success:
                 log.error(u'{} failed on {}'.format(self, server))
                 log.debug(u'ansible-output =>\n{}'.format(pformat(result)))


### PR DESCRIPTION
I have added the success flag to the results. This helps to evaluate the task in case `ignore_errors` is used.