### PR TITLE
New mitgon and ansible version support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,8 +31,9 @@ python_requires = >= 3.8
 platforms = any
 install_requires =
     ansible>=2.8.0.0
-    ansible-core<2.14
-
+    ansible-core<2.16
+    ansible-base
+    
 [options.extras_require]
 dev =
     bandit[toml]
@@ -41,7 +42,7 @@ dev =
     pre-commit
     tox
 tests =
-    mitogen>=0.2.8
+    mitogen>=0.3.7
     paramiko
     port-for
     pytest


### PR DESCRIPTION
Addresses issue #49 

Ansible-base now required as ansible_collections.ansible.builtin was moved out of ansible.
This might cause problems with backwards compatibility of ansible-core older 2.14

========================================================================================= 30 passed, 4 skipped, 2 warnings in 12.09s =========================================================================================